### PR TITLE
Honor Kubernetes CSR spec.expirationSeconds to control cert duration

### DIFF
--- a/controllers/certificatesigningrequest_controller.go
+++ b/controllers/certificatesigningrequest_controller.go
@@ -112,7 +112,7 @@ func (r *CertificateSigningRequestSigningReconciler) Reconcile(ctx context.Conte
 
 				// sign the csr before approve
 				// otherwise, the kube-controller-manager will sign the csr
-				cert, err := r.Signer.Sign(x509cr, csr.Spec.Usages)
+				cert, err := r.Signer.Sign(x509cr, csr.Spec)
 				if err != nil {
 					return ctrl.Result{}, fmt.Errorf("error auto signing csr: %v", err)
 				}


### PR DESCRIPTION
The [GA](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2784-csr-duration#ga) requirements for the Kubernetes CSR Duration KEP state:

> Inform external signer implementations of the `spec.expirationSeconds` field

`SUSE/kucero` is an external signer implementation.  This change outlines how this signer may be updated to honor this new field.