### PR TITLE
Fix install kustomize rate limit issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,10 @@ jobs:
           image: "kindest/node:${{ matrix.k8s }}"
 
       - name: Install kustomize
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v4.5.7/hack/install_kustomize.sh" | bash -s -- 4.5.7
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v5.0.3/hack/install_kustomize.sh" | bash -s -- 4.5.7
           sudo mv kustomize /usr/local/bin/kustomize
 
       - name: E2E Test


### PR DESCRIPTION
Update kustomize install script which supports passing GitHub token to avoid GitHub API rate limit issue.