### PR TITLE
Match module path to the repository location

### DIFF
--- a/cmd/kucero/main.go
+++ b/cmd/kucero/main.go
@@ -38,10 +38,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/kured/pkg/daemonsetlock"
 
-	"github.com/jenting/kucero/controllers"
-	"github.com/jenting/kucero/pkg/host"
-	"github.com/jenting/kucero/pkg/pki/node"
-	"github.com/jenting/kucero/pkg/pki/signer"
+	"github.com/hsiaoairplane/kucero/controllers"
+	"github.com/hsiaoairplane/kucero/pkg/host"
+	"github.com/hsiaoairplane/kucero/pkg/pki/node"
+	"github.com/hsiaoairplane/kucero/pkg/pki/signer"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/controllers/certificatesigningrequest_controller.go
+++ b/controllers/certificatesigningrequest_controller.go
@@ -34,8 +34,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenting/kucero/pkg/pki/cert"
-	"github.com/jenting/kucero/pkg/pki/signer"
+	"github.com/hsiaoairplane/kucero/pkg/pki/cert"
+	"github.com/hsiaoairplane/kucero/pkg/pki/signer"
 )
 
 // CertificateSigningRequestSigningReconciler reconciles a CertificateSigningRequest object

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jenting/kucero
+module github.com/hsiaoairplane/kucero
 
 go 1.26.0
 

--- a/pkg/pki/cert/kubeadm/exec.go
+++ b/pkg/pki/cert/kubeadm/exec.go
@@ -32,8 +32,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenting/kucero/pkg/host"
-	"github.com/jenting/kucero/pkg/pki/clock"
+	"github.com/hsiaoairplane/kucero/pkg/host"
+	"github.com/hsiaoairplane/kucero/pkg/pki/clock"
 )
 
 // kubeadmConfigPath is where the kubeadm ClusterConfiguration is written for

--- a/pkg/pki/cert/kubeadm/exec_test.go
+++ b/pkg/pki/cert/kubeadm/exec_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jenting/kucero/pkg/pki/clock"
+	"github.com/hsiaoairplane/kucero/pkg/pki/clock"
 )
 
 func Test_parseKubeadmCertsCheckExpiration(t *testing.T) {

--- a/pkg/pki/cert/kubeadm/kubeadm.go
+++ b/pkg/pki/cert/kubeadm/kubeadm.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenting/kucero/pkg/host"
-	"github.com/jenting/kucero/pkg/pki/cert"
-	"github.com/jenting/kucero/pkg/pki/clock"
+	"github.com/hsiaoairplane/kucero/pkg/host"
+	"github.com/hsiaoairplane/kucero/pkg/pki/cert"
+	"github.com/hsiaoairplane/kucero/pkg/pki/clock"
 )
 var certificates map[string]string = map[string]string{
 	"admin.conf":               "/etc/kubernetes/admin.conf",

--- a/pkg/pki/cert/null/null.go
+++ b/pkg/pki/cert/null/null.go
@@ -19,7 +19,7 @@ package null
 import (
 	"time"
 
-	"github.com/jenting/kucero/pkg/pki/cert"
+	"github.com/hsiaoairplane/kucero/pkg/pki/cert"
 )
 
 type Null struct {

--- a/pkg/pki/conf/kubelet/kubelet.go
+++ b/pkg/pki/conf/kubelet/kubelet.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/jenting/kucero/pkg/host"
-	"github.com/jenting/kucero/pkg/pki/conf"
+	"github.com/hsiaoairplane/kucero/pkg/host"
+	"github.com/hsiaoairplane/kucero/pkg/pki/conf"
 )
 
 type Kubelet struct {

--- a/pkg/pki/node/node.go
+++ b/pkg/pki/node/node.go
@@ -19,11 +19,11 @@ package node
 import (
 	"time"
 
-	"github.com/jenting/kucero/pkg/pki/cert"
-	"github.com/jenting/kucero/pkg/pki/cert/kubeadm"
-	"github.com/jenting/kucero/pkg/pki/cert/null"
-	"github.com/jenting/kucero/pkg/pki/conf"
-	"github.com/jenting/kucero/pkg/pki/conf/kubelet"
+	"github.com/hsiaoairplane/kucero/pkg/pki/cert"
+	"github.com/hsiaoairplane/kucero/pkg/pki/cert/kubeadm"
+	"github.com/hsiaoairplane/kucero/pkg/pki/cert/null"
+	"github.com/hsiaoairplane/kucero/pkg/pki/conf"
+	"github.com/hsiaoairplane/kucero/pkg/pki/conf/kubelet"
 )
 
 type Node struct {

--- a/pkg/pki/signer/ca_provider.go
+++ b/pkg/pki/signer/ca_provider.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
 
-	"github.com/jenting/kucero/pkg/pki/authority"
+	"github.com/hsiaoairplane/kucero/pkg/pki/authority"
 )
 
 func newCAProvider(caFile, caKeyFile string) (*caProvider, error) {

--- a/pkg/pki/signer/signer.go
+++ b/pkg/pki/signer/signer.go
@@ -25,7 +25,7 @@ import (
 	capi "k8s.io/api/certificates/v1"
 	"k8s.io/client-go/util/certificate/csr"
 
-	"github.com/jenting/kucero/pkg/pki/authority"
+	"github.com/hsiaoairplane/kucero/pkg/pki/authority"
 )
 
 type Signer struct {


### PR DESCRIPTION
## What

Renames the module from `github.com/jenting/kucero` to `github.com/hsiaoairplane/kucero`, and updates the internal import paths that follow from it.

11 files, 23 lines.

## Why

The repository was transferred to the `hsiaoairplane` organisation, but the module still declared itself under `github.com/jenting`. Fetching the canonical path fails:

```
module declares its path as: github.com/jenting/kucero
        but was required as: github.com/hsiaoairplane/kucero
```

The old path resolves only through GitHub's transfer redirect.

## Not changed

**`demo/kubeadm.cast` and `demo/kubelet.cast`** still contain the old path. These are asciinema recordings, and the string appears inside captured terminal output (shell prompts such as `jenting@opensuse:~/go/src/github.com/jenting/kucero>`). They record what a past session looked like rather than referencing anything that needs to resolve, so rewriting them would falsify the recording.

**Three pre-existing `gofmt` findings** — `pkg/pki/authority/policies.go`, `pkg/pki/cert/kubeadm/kubeadm.go`, `pkg/pki/conf/kubelet/exec.go` — are left alone. They are unformatted on `main` before this change too, and folding unrelated formatting into a rename PR would obscure the diff.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` all pass; the three packages that have tests are green.